### PR TITLE
Added npm script buildCode that only build the code without reextract…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,8 @@ If you have Node installed, run
   to install all dependencys
 - `npm run build`  
    to generate the `dist` folder that you can deploy to your server
+- `npm run buildCode`
+   same as `build`, but does not repackage the assets to save time (assumes `build` has already been run once to get the assets)
 - `npm run dev`  
   to serve the website on local host.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A tool to generate Twilight Imperium Maps for Shattered Ascension",
   "private": true,
   "scripts": {
-    "build": "node scripts/pack.mjs",
+    "build": "node scripts/pack.mjs true",
+    "buildCode": "node scripts/pack.mjs false",
     "dev": "serve dist",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -7,9 +7,10 @@
 // The idea is that once you have packaged the assets in the dist folder, there is no need to do it again (unless the assets change of course)
 // every time you build the application to try a code change
 const packAssets = process.argv[2] == "true"
-console.log("packAssets", packAssets)
-if (!packAssets) {
-    console.log("packAssets flag false -> not packing asset files")
+if (packAssets) {
+    console.log("packAssets", packAssets)
+} else {
+    console.log("packAssets false -> not packing asset files")
 }
 
 import { promises as fs } from "fs";

--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -93,11 +93,10 @@ async function readFiles(p) {
     }, {});
 }
 
-if (packAssets) {
-    console.log('copy local assets');
-    copyFolderRecursiveSync('./assets', './dist/')
-    copyFolderRecursiveSync('./css', './dist/')
-}
+console.log('copy local assets');
+// The assets folder only contains css sheets and manifests. The actual jpgs and pngs come from the zip extracted earlier in this script
+copyFolderRecursiveSync('./assets', './dist/')
+copyFolderRecursiveSync('./css', './dist/')
 
 console.log('copy index.html');
 copyFileSync('index.html', './dist/index.html')


### PR DESCRIPTION
…ing the assets

It's `npm run buildCode`
The idea is that it's annoying to see the build script spend time reextracting the assets and re-moving them to the dist folder every time I want to try a code change. This build script is meant to be used after the normal one has already packaged the assets and it just builds the code, assuming the assets are already packaged.